### PR TITLE
Added content components for Episodes

### DIFF
--- a/src/components/episodes-list/episodes-list.css
+++ b/src/components/episodes-list/episodes-list.css
@@ -1,0 +1,108 @@
+@import '../variables';
+
+.episodes-list {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  @media (--large-up) {
+    box-sizing: border-box;
+    float: left;
+    width: 50%;
+
+    &:nth-child(even) {
+      align-items: flex-end;
+    }
+
+    &:nth-child(odd) {
+      align-items: flex-start;
+    }
+  }
+
+  @media (--xl-up) {
+    padding-right: var(--space-half-vw);
+    padding-left: var(--space-half-vw);
+  }
+
+  &:not(:last-child) {
+    @media (--medium-up) {
+      padding-bottom: 0;
+    }
+
+    @media (--large-up) {
+      padding-bottom: var(--space-one-half-vw);
+    }
+  }
+
+  h2 {
+    margin-bottom: var(--space-double);
+  }
+
+  & > * {
+    max-width: 33.75rem;
+    width: 100%;
+  }
+}
+
+.episodes-list-list {
+  list-style: none;
+
+  a {
+    text-decoration: none;
+    color: inherit;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.episodes-list-entry {
+  margin-bottom: var(--space-single);
+
+  @media (--medium-up) {
+    margin-bottom: var(--space-one-half);
+  }
+}
+
+.episodes-list-title {
+  color: var(--color-dark-blue);
+  font-family: var(--font-serif);
+  font-size: var(--size-medium);
+  margin-bottom: var(--space-half);
+}
+
+.episodes-list-meta {
+  color: var(--color-light-gray);
+  font-family: var(--font-sans-serif);
+  font-size: var(--size-small);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.episodes-list-authors a {
+  color: var(--color-light-blue);
+
+  &:not(:last-child)::after {
+    content: ", ";
+  }
+}
+
+.episodes-list-date {
+  display: inline;
+  white-space: nowrap;
+
+  &::before {
+    content: " | ";
+    margin: 0 0.125em;
+  }
+}
+
+.rarr {
+  background: no-repeat center 100%;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><path d='M6,4L10,8L6,12' fill='none' stroke='%23F74D7B' stroke-width='2'/></svg>");
+  display: inline-block;
+  margin-left: 0.25em;
+  width: 1em;
+  height: 1em;
+}

--- a/src/components/episodes-list/episodes-list.js
+++ b/src/components/episodes-list/episodes-list.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'gatsby';
+
+import './episodes-list.css';
+import Text from '../text';
+import Content from '../content';
+
+EpisodesList.propTypes = {
+  heading: PropTypes.node.isRequired,
+  episodes: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    slug: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    date: PropTypes.string.isRequired,
+    authors: PropTypes.arrayOf(PropTypes.shape({
+      slug: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired
+    })).isRequired
+  })).isRequired
+};
+
+export default function EpisodesList({
+  heading,
+  episodes
+}) {
+  return (
+    <Content className="episodes-list">
+      {heading}
+
+      <ul className="episodes-list-list">
+        {episodes.map(episode => (
+          <li key={episode.id} className="episodes-list-entry">
+            <Text tag="h3" className="episodes-list-title">
+              <Link to={`/podcast/${episode.slug}`}>
+                <Text>{episode.title}</Text>
+              </Link>
+            </Text>
+
+            <Text tag="p" className="episodes-list-meta">
+              <span className="episodes-list-authors">
+                {episode.authors.map((author, i) => (
+                  <Link key={i} to={author.slug}>
+                    <Text>{author.name}</Text>
+                  </Link>
+                ))}
+              </span>
+
+              <span className="episodes-list-date">
+                {episode.date}
+              </span>
+            </Text>
+          </li>
+        ))}
+      </ul>
+    </Content>
+  );
+}

--- a/src/components/episodes-list/index.js
+++ b/src/components/episodes-list/index.js
@@ -1,0 +1,1 @@
+export { default } from './episodes-list';

--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Helmet from "react-helmet";
 
-import { Link, graphql } from "gatsby";
+import { graphql } from "gatsby";
 import Layout from "../../components/layout";
 import Hero from "../../components/hero";
 import Text from "../../components/text";

--- a/src/pages/podcast/index.js
+++ b/src/pages/podcast/index.js
@@ -1,42 +1,42 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Link, graphql } from "gatsby";
-import Layout from "../../components/layout";
+import { graphql } from "gatsby";
 import Helmet from "react-helmet";
 // import Img from "gatsby-image"
+
+import Layout from "../../components/layout";
+import EpisodesList from "../../components/episodes-list";
+import Text from "../../components/text";
 
 const PodcastPage = ({
   data: {
     site: {
       siteMetadata: { title }
     },
-    allSimplecastEpisode: {
-      edges
-    }
+    allSimplecastEpisode: { edges }
   }
 }) => {
-  let episodes = edges.map(({ node }) => node);
-
   return (
     <Layout>
-      <Helmet title={`Team | ${title}`} />
-      <ul>
-        {episodes.map(episode => (
-          <li key={episode.id}>
-            <h3><Link to={`/podcast/${episode.slug}`} >{episode.title}</Link></h3>
-            <p>{episode.description}</p>
-            <ul>
-              {episode.authors.map(author => (
-                <li key={author.fields.slug}>
-                  <Link to={author.fields.slug}>
-                    {author.frontmatter.name}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </li>
-        ))}
-      </ul>
+      <Helmet title={`Podcast | ${title}`} />
+      <EpisodesList
+        heading={
+          <Text tag="h2" align="center">
+            The Frontside Podcast
+          </Text>
+        }
+        episodes={edges.map(({ node }) => ({
+          title: node.title,
+          slug: node.slug,
+          id: node.id,
+          description: node.description,
+          date: new Date(node.publishedAt).toLocaleDateString("en-US"),
+          authors: node.authors.map(author => ({
+            slug: author.fields.slug,
+            name: author.frontmatter.name
+          }))
+        }))}
+      />
     </Layout>
   );
 };
@@ -64,6 +64,7 @@ export const episodesQuery = graphql`
           description
           longDescriptionHtml
           slug
+          publishedAt
           authors {
             frontmatter {
               name

--- a/src/templates/episode.js
+++ b/src/templates/episode.js
@@ -2,32 +2,40 @@ import React from "react";
 import Helmet from "react-helmet";
 import { Link, graphql } from "gatsby";
 import Layout from "../components/layout";
+import Content from "../components/content";
+import Text from "../components/text";
 
-function EpisodeRoute({
+export default function EpisodeRoute({
   data: {
     site: {
       siteMetadata: { title: siteTitle }
     },
-    simplecastEpisode: { title, longDescriptionHtml, authors }
+    simplecastEpisode: { title, longDescriptionHtml, authors, publishedAt }
   }
 }) {
   return (
     <Layout>
       <Helmet title={`${title} | ${siteTitle}`} />
-      <h1>{title}</h1>
-      <div dangerouslySetInnerHTML={{ __html: longDescriptionHtml }} />
-      <ul>
-        {authors.map(author => (
-          <li key={author.fields.slug}>
-            <Link to={author.fields.slug}>{author.frontmatter.name}</Link>
-          </li>
-        ))}
-      </ul>
+      <Content>
+        <Text tag="h1">{title}</Text>
+        <Text tag="p">
+          Hosts:{" "}
+          {authors.map((author, i) => (
+            <span key={author.fields.slug}>
+              <Link to={author.fields.slug}>
+                {author.frontmatter.name}
+              </Link>
+              {authors.length > i + 1 ? ", " : null}
+            </span>
+          ))}
+          <br />
+          Published on: {new Date(publishedAt).toLocaleDateString("en-US")}
+        </Text>
+        <div dangerouslySetInnerHTML={{ __html: longDescriptionHtml }} />
+      </Content>
     </Layout>
   );
 }
-
-export default EpisodeRoute;
 
 export const episodePageQuery = graphql`
   query EpisodePage($id: String!) {

--- a/src/templates/episode.js
+++ b/src/templates/episode.js
@@ -10,27 +10,36 @@ export default function EpisodeRoute({
     site: {
       siteMetadata: { title: siteTitle }
     },
-    simplecastEpisode: { title, longDescriptionHtml, authors, publishedAt }
+    simplecastEpisode: { title, longDescriptionHtml, authors, publishedAt, sharingUrl }
   }
 }) {
+  let [,shareId] = sharingUrl.match(/.*\/(.*)$/);
+
   return (
     <Layout>
       <Helmet title={`${title} | ${siteTitle}`} />
       <Content>
         <Text tag="h1">{title}</Text>
-        <Text tag="p">
+        <iframe
+          frameBorder="0"
+          height="200px"
+          scrolling="no"
+          seamless
+          src={`https://embed.simplecast.com/${shareId}?color=f5f5f5`}
+          width="100%"
+          title="Podcast episode player"
+        />
+        <p>
           Hosts:{" "}
           {authors.map((author, i) => (
             <span key={author.fields.slug}>
-              <Link to={author.fields.slug}>
-                {author.frontmatter.name}
-              </Link>
+              <Link to={author.fields.slug}>{author.frontmatter.name}</Link>
               {authors.length > i + 1 ? ", " : null}
             </span>
           ))}
           <br />
           Published on: {new Date(publishedAt).toLocaleDateString("en-US")}
-        </Text>
+        </p>
         <div dangerouslySetInnerHTML={{ __html: longDescriptionHtml }} />
       </Content>
     </Layout>
@@ -46,13 +55,10 @@ export const episodePageQuery = graphql`
     }
     simplecastEpisode(id: { eq: $id }) {
       id
-      season
-      number
       title
       description
       longDescriptionHtml
       publishedAt
-      audioUrl
       sharingUrl
       authors {
         frontmatter {


### PR DESCRIPTION
# Purpose

This PR applies similar patterns used on Blog and design introduced in #11. I copied PostsWidget to EpisodesList and applied some formatting that's specific to the Podcast.

# Todo

- [ ] Apply responsive styles
- [x] Add audio player to podcast episode page

# Screenshots

![2019-01-10 18 31 59](https://user-images.githubusercontent.com/74687/51003914-8cef7080-1506-11e9-875c-73b518cc8ff8.gif)

![2019-01-10 18 32 22](https://user-images.githubusercontent.com/74687/51003918-911b8e00-1506-11e9-8711-25c1f6abed2c.gif)

