### PR TITLE
Fix responsive homepage bug

### DIFF
--- a/src/components/box/box.css
+++ b/src/components/box/box.css
@@ -8,6 +8,7 @@
 .flex-row {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
 }
 
 .flex-align-start { align-items: flex-start; }

--- a/src/components/posts-widget/posts-widget.css
+++ b/src/components/posts-widget/posts-widget.css
@@ -4,24 +4,22 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  max-width: 33.75rem;
+  width: 100%;
 
   @media (--large-up) {
     box-sizing: border-box;
-    float: left;
+    padding-right: var(--space-double);
+    padding-left: var(--space-double);
     width: 50%;
 
     &:nth-child(even) {
-      align-items: flex-end;
+      margin-left: 0;
     }
 
     &:nth-child(odd) {
-      align-items: flex-start;
+      margin-right: 0;
     }
-  }
-
-  @media (--xl-up) {
-    padding-right: var(--space-half-vw);
-    padding-left: var(--space-half-vw);
   }
 
   &:not(:last-child) {
@@ -36,11 +34,6 @@
 
   h2 {
     margin-bottom: var(--space-double);
-  }
-
-  & > * {
-    max-width: 33.75rem;
-    width: 100%;
   }
 }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,6 +6,7 @@ import Layout from '../components/layout';
 import Hero from '../components/hero';
 import Content from '../components/content';
 import Text from '../components/text';
+import Box from '../components/box';
 import Button, { ButtonGroup } from '../components/button';
 import HomeLogos, { Logo } from '../components/home-logos';
 import PostsWidget from '../components/posts-widget';
@@ -82,35 +83,36 @@ export default function IndexPage({
         </ButtonGroup>
       </Content>
 
-      <PostsWidget
-        heading="Latest on the blog"
-        linkTo="/blog"
-        posts={posts.map(({ node }) => ({
-          id: node.id,
-          slug: node.fields.slug,
-          title: node.frontmatter.title,
-          date: node.frontmatter.date,
-          authors: node.fields.authors.map(author => ({
-            slug: author.fields.slug,
-            name: author.frontmatter.name
-          }))
-        }))}
-      />
-
-      <PostsWidget
-        heading="Latest on the podcast"
-        linkTo="/podcast"
-        posts={episodes.map(({ node })=> ({
-          id: node.id,
-          slug: `/podcast/${node.slug}`,
-          title: node.title,
-          date: node.publishedAt,
-          authors: node.authors.map(author => ({
-            slug: author.fields.slug,
-            name: author.frontmatter.name
-          }))
-        }))}
-      />
+      <Box direction="row" justify="center">
+        <PostsWidget
+          heading="Latest on the blog"
+          linkTo="/blog"
+          posts={posts.map(({ node }) => ({
+            id: node.id,
+            slug: node.fields.slug,
+            title: node.frontmatter.title,
+            date: node.frontmatter.date,
+            authors: node.fields.authors.map(author => ({
+              slug: author.fields.slug,
+              name: author.frontmatter.name
+            }))
+          }))}
+        />
+        <PostsWidget
+          heading="Latest on the podcast"
+          linkTo="/podcast"
+          posts={episodes.map(({ node })=> ({
+            id: node.id,
+            slug: `/podcast/${node.slug}`,
+            title: node.title,
+            date: node.publishedAt,
+            authors: node.authors.map(author => ({
+              slug: author.fields.slug,
+              name: author.frontmatter.name
+            }))
+          }))}
+        />
+      </Box>
     </Layout>
   );
 }


### PR DESCRIPTION
## Purpose

The post-widget areas were less than 100% width together on larger screens so it allowed the footer to appear beside it due to their float-left property.


## Approach

This wraps them in a generic flexbox row instead of using float. This also fixes their alignment to be in the center on larger screens.