### PR TITLE
Add hotjar

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -91,6 +91,13 @@ module.exports = {
         podcastId: 96
       },
     },
+    {
+      resolve: `gatsby-plugin-hotjar`,
+      options: {
+        id: 859026,
+        sv: 6
+      },
+    },
     'gatsby-connect-authors',
     'gatsby-plugin-netlify', // make sure to keep it last in the array
   ],

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "classnames": "^2.2.6",
     "gatsby": "^2.0.0",
     "gatsby-image": "^2.0.22",
+    "gatsby-plugin-hotjar": "^1.0.1",
     "gatsby-plugin-netlify": "^2.0.0",
     "gatsby-plugin-netlify-cms": "^3.0.0",
     "gatsby-plugin-postcss": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6855,6 +6855,13 @@ gatsby-link@^2.0.7:
     "@types/reach__router" "^1.0.0"
     prop-types "^15.6.1"
 
+gatsby-plugin-hotjar@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-hotjar/-/gatsby-plugin-hotjar-1.0.1.tgz#f5703d7d2a354752e20230a0074d53c7287d8950"
+  integrity sha512-1iZIftJin3Ti51ho7HiGes2ZiXZhU0/sSe6OCvULy3F9hSpADrX5jU48ajnZnrS1O0lf7pyVfjvBBpXOawASHw==
+  dependencies:
+    babel-runtime "^6.26.0"
+
 gatsby-plugin-netlify-cms@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-netlify-cms/-/gatsby-plugin-netlify-cms-3.0.9.tgz#d525774b1079e5ae9d3ea887e10e674541d75b28"


### PR DESCRIPTION
### Purpose

Hotjar is what we use on the current site to understand how visitors are interacting with it.

### Approach

Even though it's pretty paper-thin, I went with the existing [hotjar gatsby plugin][1] to install its snippet into our site.

Note that since the HOTJAR_ID and HOTJAR_VERSION are publicly available (they're embedded into the JS snippet), I didn't bother hiding them behind environment variables.

Also, the plugin behavior is that this only adds hotjar in production. That way, your staging website doesn't bork up your production hotjar data. 

Ideally, we'd use a different hotjar configuration for staging than for production instead of nothing at all so that we can at least verify that it's working, but I think this is fine for now.

[1]: https://www.gatsbyjs.org/packages/gatsby-plugin-hotjar/?=hotj