### PR TITLE
Update people pages

### DIFF
--- a/src/pages/people/alex-ford.md
+++ b/src/pages/people/alex-ford.md
@@ -5,6 +5,5 @@ title: Frontside Alumnus
 img: /img/alex-ford.png
 twitter: flexyford
 github: flexyford
-bio: Alex Ford is a Computer Engineer turned Developer. After dabbling in semiconductor design and low level programming, he realized "coding for the browser is just more fun than coding for anything else”. When he isn’t working on software, Alex is cycling, rock-climbing, kayaking and playing cribbage. Although he claims the wolf as his spirit animal, a meerkat is probably more accurate.
 alumnus: true
 ---

--- a/src/pages/people/arash-zafarnia.md
+++ b/src/pages/people/arash-zafarnia.md
@@ -4,6 +4,5 @@ name: Arash Zafarnia
 title: Frontside Alumnus
 img: /img/arash-headshot.jpg
 twitter: actualarash
-bio: Arash has been working for digital agencies for the entirety of his grownup life. He is not a fan of referring to himself in the third person but he spends most of his time thinking about how to create an environment that allows people to do their best work and gives them the best chance at success.
 alumnus: true
 ---

--- a/src/pages/people/brandon-hays.md
+++ b/src/pages/people/brandon-hays.md
@@ -5,6 +5,5 @@ title: Frontside Alumnus
 img: /img/brandon-hays.png
 twitter: tehviking
 github: tehviking
-bio: Brandon is a marketer-turned-programmer who can't help but evangelize the joys of making things. His passions are writing, using technology to delight real people, and lightsaber battles with his kids.
 alumnus: true
 ---

--- a/src/pages/people/chris-freeman.md
+++ b/src/pages/people/chris-freeman.md
@@ -5,6 +5,5 @@ title: Frontside Alumnus
 img: /img/chris-freeman.png
 twitter: 15lettermax
 github: cafreeman
-bio: Chris ended up developing software by accident. After getting degrees in Political Science and Economics, he worked as a data analyst before going to work on analytics software and realizing that programming is actually the best. He’s written open source software in R, Scala, and now Javascript, and basically just likes anything that involves a text editor and higher-order functions. In his spare time, he enjoys cooking, listening to podcasts, reading about other programming languages, and spending time with his fiancé and their (awesome) army of (awesome) cats.
 alumnus: true
 ---

--- a/src/pages/people/elrick-ryan.md
+++ b/src/pages/people/elrick-ryan.md
@@ -5,6 +5,5 @@ title: Frontside Alumnus
 img: /img/elrick-ryan.jpg
 twitter: elrickvm
 github: elrickvm
-bio: Elrick is a mashup of developer and designer he has coined Devsigner X. He holds bachelors degrees in both Web Development and Multimedia Design. Capable of taking ideas all the way from a dot grid notebook, through the design phase, and into production, he loves the challenge of bringing amazing design to life with code. Creativity is in his blood. Problem solving is at his core. Collaboration is in his heart. He fell in love with code because of design and because of Flash fell in love with JavaScript and has never looked back. He has designed for many different mediums and has written code across the full breadth of the stack which makes him truly The B.O.A.T. -- The Builder Of All Things. When he is not designing or coding he is doing one of many hobbies to long to list here. You can ask him about them when you meet him though, he loves people.
 alumnus: true
 ---

--- a/src/pages/people/ginger-whalen.md
+++ b/src/pages/people/ginger-whalen.md
@@ -5,8 +5,5 @@ title: Frontside Alumnus
 img: /img/ginger-whalen.jpg
 twitter: gingerwhalen
 github: gingerspice5
-bio: "Ginger gets you to your goals yet stays in touch with the human experience. She’s been building rocket fueled partnerships with large and small tech companies for nearly a million years.
-
-As a former ultra distance athlete, she figured out collaboration is a lot more fun than competition. Sucker for live music, MOOCs and pandas."
 alumnus: true
 ---

--- a/src/pages/people/index.js
+++ b/src/pages/people/index.js
@@ -38,17 +38,6 @@ const PeoplePage = ({
           </li>
         ))}
       </ul>
-      <h2>Alumni</h2>
-      <ul>
-        {alumni.map(person => (
-          <li key={person.frontmatter.name}>
-            <Link to={person.fields.slug}>
-              <Img fixed={person.frontmatter.img.childImageSharp.fixed} />
-              {person.frontmatter.name}
-            </Link>
-          </li>
-        ))}
-      </ul>
     </Layout>
   );
 };

--- a/src/pages/people/jeffrey-cherewaty.md
+++ b/src/pages/people/jeffrey-cherewaty.md
@@ -1,9 +1,9 @@
 ---
 templateKey: people
 name: Jeffrey Cherewaty
-title: Puzzle Solver
+title: Software Diplomat
 img: /img/jeffrey-cherewaty.jpg
 twitter: cherewaty
 github: cherewaty
-bio: Jeffrey is a startup veteran who likes building thoughtfully designed apps in the browser. He wrote PHP in a past life, and still has scars from CSS layouts in IE6. These days he’s all-in on modern JavaScript. Jeffrey believes in empathy, constant learning, and King Ranch chicken. His autobiography would be set in Futura and Sentinel.
+bio: Jeffrey is a seasoned designer/developer who likes creating thoughtfully designed apps in the browser. He began his career building accessible websites for The University of Texas at Austin. As SpareFoot’s first employee, he led design and front-end engineering through exponential growth and multiple fundraising rounds. At Frontside, Jeffrey prides himself on shipping beautiful, livable code that solves real business problems. He’s currently working on a Master’s in Software Engineering at UT-Austin.
 ---

--- a/src/pages/people/joe-lasala.md
+++ b/src/pages/people/joe-lasala.md
@@ -5,6 +5,5 @@ title: Frontside Alumnus
 img: /img/joe-lasala.jpg
 twitter: salsanotsalsa
 github: sadatay
-bio: Joe is someone who is motivated by collaboration, creative problem-solving, and curiosity above all else.  He also happens to be a software developer.  He has produced pounds of Perl in Pittsburgh, ran with Rails and grappled with Go south of San Francisco, and has now settled in to author applications in Austin.  Joe is excited to hone his front-end skills with the fine people of the Frontside.  He's not usually this alliterative.
 alumnus: true
 ---

--- a/src/pages/people/laura-hillmann.md
+++ b/src/pages/people/laura-hillmann.md
@@ -5,6 +5,5 @@ title: Frontside Alumnus
 img: /img/laura-hillmann.png
 twitter: hillmoma
 github: hillmoma
-bio: Geek. Overthinker. Mom. Laura is awesome. She hates writing bios.
 alumnus: true
 ---

--- a/src/pages/people/lydia-guarino.md
+++ b/src/pages/people/lydia-guarino.md
@@ -1,0 +1,6 @@
+---
+templateKey: people
+name: Lydia Guarino
+title: Frontside Alumnus
+alumnus: true
+---

--- a/src/pages/people/robert-deluca.md
+++ b/src/pages/people/robert-deluca.md
@@ -5,6 +5,5 @@ title: Frontside Alumnus
 img: /img/robert-deluca.jpg
 twitter: robdel12
 github: robdel12
-bio: Robert has been contributing to open source for almost as long as he has been writing code. As Director of Open Source & Community Engagement, Robert is in charge of making sure Frontsiders are engaging with the wider community & giving back where they can. When not contributing to open source, he enjoys designing great JavaScript powered user experiences by crafting them in CSS/SCSS and ensuring their accessibility. In his spare time, you can find Robert hanging out by the pool with his wife & dog, tinkering on home automation, & watching college football on Saturdays (go 'canes!).
 alumnus: true
 ---

--- a/src/pages/people/sam-keathley.md
+++ b/src/pages/people/sam-keathley.md
@@ -5,6 +5,5 @@ title: Frontside Alumnus
 img: /img/sam-keathley.jpg
 twitter: SamKeathley
 github: SamKeathley
-bio: Sam is a software developer who values learning and collaborating with her team. She has a creative mind and finds great value in thinking outside of the box to solve problems whenever possible. She also loves making people laugh as much as she can. In her free time you'll probably find Sam playing with her dog, drawing, reading, or doing nerd things like playing Dungeons and Dragons with her friends.
 alumnus: true
 ---

--- a/src/pages/people/stanley-stuart.md
+++ b/src/pages/people/stanley-stuart.md
@@ -1,0 +1,6 @@
+---
+templateKey: people
+name: Stanley Stuart
+title: Frontside Alumnus
+alumnus: true
+---

--- a/src/pages/people/stephanie-riera.md
+++ b/src/pages/people/stephanie-riera.md
@@ -5,6 +5,5 @@ title: Frontside Alumnus
 img: /img/stephanie-riera.png
 twitter: stefriera
 github: ssriera
-bio: Texan born & raised in Europe, Stephanie received her degree in Molecular Biology and transitioned into programming a year after graduation. She loves programming because it provides the ability to create your own opportunities. Passionate about women's empowerment, she has organized the first Rails Girls in San Antonio, co-organized Emberitas in Austin, and is a firm believer in giving back to the community. Collecting vinyl, music festivals, and traveling are her favorite pastimes.
 alumnus: true
 ---

--- a/src/pages/people/wil-wilsman.md
+++ b/src/pages/people/wil-wilsman.md
@@ -1,9 +1,9 @@
 ---
 templateKey: people
 name: Wil Wilsman
-title: Software Tinkerer
+title: Frontside Alumnus
 img: /img/wil-wilsman.jpg
 twitter: wilwilsman
 github: wwilsman
-bio: Wil went to school in hopes of becoming a Graphic Designer but by the end realized his true passion was in development. He loves tackling tough challenges like finding solutions to UX problems or fixing complex, hard-to-solve bugs. What he loves most though is learning new things and he strongly believes that there is always more to learn no matter how much you already know about a subject. When he isn't slinging code, he's keeping up with the latest technologies, learning useless skills like solving Rubik's Cubes, or playing video games with his wife.
+alumnus: true
 ---

--- a/src/templates/people.js
+++ b/src/templates/people.js
@@ -29,13 +29,19 @@ const PersonPage = ({
   return (
     <Layout>
       <Helmet title={`Team | ${title}`} />
-      <Img fixed={img.childImageSharp.fixed} />
+      {img && (
+        <Img fixed={img.childImageSharp.fixed} />
+      )}
       <h1>{name}</h1>
       <div className="person-title">{personTitle}</div>
       <p>{bio}</p>
       <ul>
-        <li>Twitter: <a href={`https://twitter.com/${twitter}`}>{twitter}</a></li>
-        <li>GitHub: <a href={`https://github.com/${github}`}>{github}</a></li>
+        {twitter && (
+          <li>Twitter: <a href={`https://twitter.com/${twitter}`}>{twitter}</a></li>
+        )}
+        {github && (
+          <li>GitHub: <a href={`https://github.com/${github}`}>{github}</a></li>
+        )}
       </ul>
       {posts.length ? (
         <div>


### PR DESCRIPTION
- Updated my own bio.
- Edited person template to render fine even in the absence of photo, Github, Twitter, etc.
- Removed bios from alumni pages. I don't think we want to be in the business of keeping those up-to-date (or alternatively, having really out-of-date information).
- Added pages for Stanley and Lydia, since they were podcast hosts several times.
- Removed links on people index to alumni pages.