### PR TITLE
Add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ public/
 static/admin/*.bundle.*
 .DS_Store
 yarn-error.log
+.env
+.env.development


### PR DESCRIPTION
So I don't accidentally check in my local `.env`.