### PR TITLE
Fix David’s status

### DIFF
--- a/src/pages/people/david-keathley.md
+++ b/src/pages/people/david-keathley.md
@@ -6,5 +6,4 @@ img: /img/david-keathley.jpg
 twitter: endertux
 github: keathleydavidj
 bio: David is a code bootcamp graduate who comes from a background in auto mechanics and fintech. As a functional programming advocate, David thinks a lot about reducing cognitive load and barriers to entry for new developers. Outside of work he is into PC gaming, mechanical keyboards, and astronomy.
-alumnus: true
 ---


### PR DESCRIPTION
David wasn't showing up on the about page because he had `alumnus: true`. False.

<img width="855" alt="screen shot 2019-01-28 at 3 55 47 pm" src="https://user-images.githubusercontent.com/230597/51869103-3ca14c80-2315-11e9-98c4-344880cb4afb.png">
