### PR TITLE
Wrap tag pages in Content component

### DIFF
--- a/src/pages/tags/index.js
+++ b/src/pages/tags/index.js
@@ -3,33 +3,36 @@ import { kebabCase } from 'lodash'
 import Helmet from 'react-helmet'
 import { Link, graphql } from 'gatsby'
 import Layout from '../../components/layout'
+import Content from '../../components/content';
 
 const TagsPage = ({
   data: { allMarkdownRemark: { group }, site: { siteMetadata: { title } } },
 }) => (
   <Layout>
-    <section className="section">
-      <Helmet title={`Tags | ${title}`} />
-      <div className="container content">
-        <div className="columns">
-          <div
-            className="column is-10 is-offset-1"
-            style={{ marginBottom: '6rem' }}
-          >
-            <h1 className="title is-size-2 is-bold-light">Tags</h1>
-            <ul className="taglist">
-              {group.map(tag => (
-                <li key={tag.fieldValue}>
-                  <Link to={`/tags/${kebabCase(tag.fieldValue)}/`}>
-                    {tag.fieldValue} ({tag.totalCount})
-                  </Link>
-                </li>
-              ))}
-            </ul>
+    <Content>
+      <section className="section">
+        <Helmet title={`Tags | ${title}`} />
+        <div className="container content">
+          <div className="columns">
+            <div
+              className="column is-10 is-offset-1"
+              style={{ marginBottom: '6rem' }}
+            >
+              <h1 className="title is-size-2 is-bold-light">Tags</h1>
+              <ul className="taglist">
+                {group.map(tag => (
+                  <li key={tag.fieldValue}>
+                    <Link to={`/tags/${kebabCase(tag.fieldValue)}/`}>
+                      {tag.fieldValue} ({tag.totalCount})
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </Content>
   </Layout>
 )
 

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -2,6 +2,7 @@ import React from 'react'
 import Helmet from 'react-helmet'
 import { Link, graphql } from 'gatsby'
 import Layout from '../components/layout'
+import Content from '../components/content'
 
 class TagRoute extends React.Component {
   render() {
@@ -19,8 +20,10 @@ class TagRoute extends React.Component {
     return (
       <Layout>
         <Helmet title={`${tag} | ${title}`} />
-        <Link to="/tags/">Browse all tags</Link>
-        <ul className="taglist">{postLinks}</ul>
+        <Content>
+          <Link to="/tags/">Browse all tags</Link>
+          <ul className="taglist">{postLinks}</ul>
+        </Content>
       </Layout>
     )
   }


### PR DESCRIPTION
Makes tag index and individual tag pages look not broken.

![localhost_8000_tags ipad pro](https://user-images.githubusercontent.com/230597/52294312-979ef900-293e-11e9-8948-069dae6fda90.png)
