### PR TITLE
Fix headline and ol styles for blog posts

### DIFF
--- a/src/components/_variables.css
+++ b/src/components/_variables.css
@@ -22,6 +22,7 @@
   --space-one-half: calc(var(--space-single) * 1.5);
   --space-double: calc(var(--space-single) * 2);
   --space-triple: calc(var(--space-single) * 3);
+  --space-quadruple: calc(var(--space-single) * 4);
 
   --space-single-vw: 10vw;
   --space-half-vw: calc(var(--space-single-vw) * 0.5);

--- a/src/components/layout/layout.css
+++ b/src/components/layout/layout.css
@@ -48,13 +48,13 @@ h1 {
 h2 {
   font-size: var(--size-large);
   margin-bottom: var(--space-single);
-  margin-top: var(--space-double);
+  margin-top: var(--space-quadruple);
 }
 
 h3 {
   font-size: var(--size-med-lg);
   margin-bottom: var(--space-single);
-  margin-top: var(--space-one-half);
+  margin-top: var(--space-quadruple);
   font-weight: 700;
 }
 
@@ -67,6 +67,12 @@ p {
 
 a {
   color: var(--link-color);
+}
+
+ol {
+  font-family: var(--font-serif);
+  font-size: var(--size-base);
+  margin: var(--space-double);
 }
 
 /* Utility Classes */


### PR DESCRIPTION
## Before
<img width="813" alt="screen shot 2019-02-19 at 12 31 00 pm" src="https://user-images.githubusercontent.com/230597/53038440-5fb9aa80-3442-11e9-9196-7b61ec480a17.png">

## After
<img width="786" alt="screen shot 2019-02-19 at 12 30 40 pm" src="https://user-images.githubusercontent.com/230597/53038428-59c3c980-3442-11e9-91b5-ca9b68bc461d.png">
